### PR TITLE
Allow taking ownership of the stdin/stdout/stderr handles.

### DIFF
--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -12,6 +12,11 @@ fn main() {
     });
 
     let mut s = String::new();
-    handle.stdout().unwrap().read_to_string(&mut s).unwrap();
+    handle
+        .stdout()
+        .take()
+        .unwrap()
+        .read_to_string(&mut s)
+        .unwrap();
     assert_eq!(s, "1 2\n");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,17 +246,17 @@ impl<T: Serialize + for<'de> Deserialize<'de>> JoinHandle<T> {
     }
 
     /// Fetch the `stdin` handle if it has been captured
-    pub fn stdin(&mut self) -> Option<&mut ChildStdin> {
-        self.process.stdin.as_mut()
+    pub fn stdin(&mut self) -> &mut Option<ChildStdin> {
+        &mut self.process.stdin
     }
 
     /// Fetch the `stdout` handle if it has been captured
-    pub fn stdout(&mut self) -> Option<&mut ChildStdout> {
-        self.process.stdout.as_mut()
+    pub fn stdout(&mut self) -> &mut Option<ChildStdout> {
+        &mut self.process.stdout
     }
 
     /// Fetch the `stderr` handle if it has been captured
-    pub fn stderr(&mut self) -> Option<&mut ChildStderr> {
-        self.process.stderr.as_mut()
+    pub fn stderr(&mut self) -> &mut Option<ChildStderr> {
+        &mut self.process.stderr
     }
 }


### PR DESCRIPTION
With the new method the user can e.g. drop the stdin handle or move any of the handles to different threads without keeping a reference to the process. There's no real reason to restrict the user and force them to use a locking scheme to achieve the same thing.