### PR TITLE
Version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ description = "Crate providing the ability to spawn processes with custom closur
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ipc-channel = "0.13.0"
-serde = { version = "1.0.104", features = ["derive"] }
+ipc-channel = "0.15.0"
+serde = { version = "1.0.130", features = ["derive"] }
 lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,10 @@
 //!
 //! `mitosis::spawn()` can pass arbitrary serializable data, including IPC senders
 //! and receivers from the `ipc-channel` crate, down to the new process.
+
 use ipc_channel::ipc::{
-    self, IpcOneShotServer, IpcReceiver, IpcSender, OpaqueIpcReceiver, OpaqueIpcSender,
+    self, IpcError, IpcOneShotServer, IpcReceiver, IpcSender, OpaqueIpcReceiver, OpaqueIpcSender,
 };
-use ipc_channel::Error as IpcError;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
 use std::path::PathBuf;


### PR DESCRIPTION
[ipc-channel](https://github.com/servo/ipc-channel) now has windows support. Using the latest version allows most of the mitosis examples, and all of the tests to work on windows.